### PR TITLE
Cli.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM python:3.8
 WORKDIR /CLI
 
 COPY requirements.txt .
-COPY src/ ./src
 
 RUN python -m pip install --upgrade pip \
-    && pip install -r requirements.txt \
+    && pip install -r requirements.txt
 
-ENTRYPOINT bash
+COPY . .
+
+ENTRYPOINT python /CLI/src/app.py
+# ENTRYPOINT bash

--- a/src/commands.py
+++ b/src/commands.py
@@ -242,9 +242,26 @@ class Grep(CommandWithArgs):
             return ''
 
 
+class CD(CommandWithArgs):
+    """
+        Class that implements cd command.
+    """
+    def __init__(self, args: list = None):
+        super().__init__('cd', args)
+
+    def __call__(self):
+        directory = os.environ['HOME'] if not self.args else self.args[0]
+        os.chdir(directory)
+        return ''
+
+class LS(CommandWithArgs):
+    """
+        Class that implements ls command.
+    """
+    def __init__(self, args: list = None):
+        super().__init__('ls', args)
 
 
-
-
-
-
+    def __call__(self):
+        directory = os.getcwd() if not self.args else self.args[0]
+        return " ".join(os.listdir(directory))

--- a/src/executor.py
+++ b/src/executor.py
@@ -11,7 +11,7 @@ class Executor:
     """
     def __init__(self, command_pipeline: [CommandWithArgs]):
         self.command_pipeline = command_pipeline
-        self.command_dict = {'cat': Cat, 'echo': Echo, 'wc': WC, 'pwd': PWD, 'exit': Exit, 'grep': Grep}
+        self.command_dict = {'cat': Cat, 'echo': Echo, 'wc': WC, 'pwd': PWD, 'exit': Exit, 'grep': Grep, 'cd': CD, 'ls': LS}
 
     def execute(self):
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -3,8 +3,7 @@ from src.expander import Expander
 import re
 import os
 
-commandDict = {'cat': Cat, 'echo': Echo, 'wc': WC, 'pwd': PWD, 'exit': Exit, 'grep': Grep}
-
+commandDict = {'cat': Cat, 'echo': Echo, 'wc': WC, 'pwd': PWD, 'exit': Exit, 'grep': Grep, 'cd': CD, 'ls': LS}
 
 class Parser:
     """

--- a/test/test_CLI.py
+++ b/test/test_CLI.py
@@ -142,10 +142,22 @@ def test_var_commands2():
     assert ans == ['1 1 3 1 1 3']
 
 
+def test_cd():
+    print("Running test for 'cd' command. Note: this test is platform specific")
+    command = 'cd /CLI'
+    _ = startup_func(command)
+    result = startup_func('pwd')
+    assert result == '/CLI'
+    print("'cd' test passed")
 
+def test_ls():
+    print("Running test for 'ls' command. Note: this test is platform specific")
+    command = 'ls /CLI/test/testdir'
+    result = startup_func(command)
+    assert result == '1 2'
+    print("'ls' test passed")
 
 if __name__ == "__main__":
-    pass
     # test_parser()
     # test_context()
     # test_expand()
@@ -155,3 +167,9 @@ if __name__ == "__main__":
     # test_pwd()
     test_var_commands2()
     #test_grep()
+
+    test_ls()
+    # since CD changes directory of the process
+    # it's best run at the end so as not to
+    # mess with other tests (or one should mess with them?)
+    test_cd()


### PR DESCRIPTION
## 1. Неочевидность запуска

В работе приняты некоторые решения, например этого, котрые заставляют задуматься о том, как
предполагалось, что будет запускаться шелл вне докер контейнера.

Это осложнило запуск шелла и тестов.

## 2. Разделение сущностей

Parser и парсит, и выполняет внешние команды.
Executor выполняет только внутренние команды.
Такое поведение не кажется очевидным.

## 3. Вызов команд

Вызов команды возвращает строку, результат своего вызова, за исключением
тех случаев, когда происходит исключительная ситуация, в этих случаях
информация пишется в стандартный вывод. 
Такое поведение не кажется очевидным.

## 4. Связность команд

Для корректной реализации было необходимо посмотреть на детали реализации команды `pwd` и, соответсвенно, `os.getcwd`. 

(Возможно этот пункт не является особенным замечанием из-за тесной связи `cd`, `ls` и `pwd`.

## Плюсы

Простота реализации шелла также отразилась на простоте реализации необходимых команд.

